### PR TITLE
Move buildconfig property to app module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,7 @@ android {
 
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
 
     compileOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,5 +24,4 @@ android.nonTransitiveRClass=true
 
 # see https://poeditor.com/docs/api for how API token may be obtained
 POEditorAPIToken=invalid
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false


### PR DESCRIPTION
With gradle 8.0, buildConfig in properties file is deprecated. We need to specify buildConfig foreach module -> https://stackoverflow.com/questions/74634321/fixing-the-build-type-contains-custom-buildconfig-fields-but-the-feature-is-di